### PR TITLE
Fixes and improvements

### DIFF
--- a/bin/test_report
+++ b/bin/test_report
@@ -7,7 +7,7 @@ class TestReport(unittest.TestCase):
 	def test_report(self):
 		try:
 			with open("/tmp/flexbe_app_report.log", 'r') as f:
-				report = yaml.load(f)
+				report = yaml.safe_load(f)
 		except IOError:
 			return # skip test since there is no report to evaluate
 		for test_type, tests in report.items():

--- a/package.xml
+++ b/package.xml
@@ -21,6 +21,7 @@
   <run_depend>genpy</run_depend>
   <run_depend>actionlib</run_depend>
   <run_depend>rospack</run_depend>
+  <run_depend>rospy_message_converter</run_depend>
 
   <test_depend>rosunit</test_depend>
 

--- a/src/_helper/checking.js
+++ b/src/_helper/checking.js
@@ -2,9 +2,9 @@ Checking = new (function() {
 	var that = this;
 
 	var python_varname_pattern = /^[a-z_][a-z0-9_]*$/i;
-	var python_reserved_list = ["and", "assert", "break", "class", "continue", "def", "del", "elif", 
-	         "else", "except", "exec", "finally", "for", "from", "global", "if", 
-	         "import", "in", "is", "lambda", "not", "or", "pass", "print", 
+	var python_reserved_list = ["and", "assert", "break", "class", "continue", "def", "del", "elif",
+	         "else", "except", "exec", "finally", "for", "from", "global", "if",
+	         "import", "in", "is", "lambda", "not", "or", "pass", "print",
 	         "raise", "return", "try", "while", "yield"];
 
 	this.checkBehavior = function() {
@@ -236,8 +236,15 @@ Checking = new (function() {
 				available_userdata = available_userdata.concat(Behavior.getDefaultUserdata().map(function(el) { return el.key; }));
 			}
 			if (!available_userdata.contains(sm_dataflow[i].getOutcome())) {
-				if (!UI.Statemachine.isDataflow()) UI.Statemachine.toggleDataflow();
-				return "input key " + sm_dataflow[i].getOutcome() + " of state " + state.getStatePath() + " could be undefined";
+				var idx = state.getParameters().indexOf(sm_dataflow[i].getOutcome())
+				if (idx >= 0 && state.getParameterValues()[idx] != "None") {
+					T.logWarn("input key " + sm_dataflow[i].getOutcome() + " of state " + state.getStatePath() + " is overwritten by parameter with same name");
+					continue;
+				}
+				else {
+					if (!UI.Statemachine.isDataflow()) UI.Statemachine.toggleDataflow();
+					return "input key " + sm_dataflow[i].getOutcome() + " of state " + state.getStatePath() + " could be undefined";
+				}
 			}
 		}
 
@@ -277,7 +284,7 @@ Checking = new (function() {
 
 		var close_stack = [];
 		var dot_last = false;
-		
+
 		for (var i = 0; i < expr.length; i++) {
 			var c = expr[i];
 			if (dot_last && !c.match(/[a-z_0-9]/i)) return false;

--- a/src/ros/ros_actionclient.js
+++ b/src/ros/ros_actionclient.js
@@ -23,14 +23,14 @@ import yaml
 
 def feedback_cb(msg):
 	comm = dict()
-	comm['msg'] = yaml.load(genpy.message.strify_message(msg))
+	comm['msg'] = yaml.safe_load(genpy.message.strify_message(msg))
 	comm['type'] = "`+TYPE_FEEDBACK+`"
 	sys.stdout.write(json.dumps(comm))
 	sys.stdout.flush()
 
 def result_cb(state, msg):
 	comm = dict()
-	comm['msg'] = yaml.load(genpy.message.strify_message(msg))
+	comm['msg'] = yaml.safe_load(genpy.message.strify_message(msg))
 	comm['state'] = str(state)
 	comm['type'] = "`+TYPE_RESULT+`"
 	sys.stdout.write(json.dumps(comm))
@@ -142,7 +142,7 @@ while not rospy.is_shutdown():
 			if (timer != undefined) clearTimeout(timer);
 			timer = setTimeout(timeout_cb, timeout);
 		}
-		
+
 	}
 
 	that.close = function() {

--- a/src/ros/ros_subscriber.js
+++ b/src/ros/ros_subscriber.js
@@ -12,9 +12,10 @@ import importlib
 import json
 import genpy
 import yaml
+from rospy_message_converter import json_message_converter
 
 def callback(msg):
-	sys.stdout.write(json.dumps(yaml.load(genpy.message.strify_message(msg))))
+	sys.stdout.write(json_message_converter.convert_ros_message_to_json(msg))
 	sys.stdout.flush()
 
 topic = sys.argv[1]


### PR DESCRIPTION
- use [rospy_message_converter](http://wiki.ros.org/rospy_message_converter) for conversion between rosmsgs and json.
- get rid of warning by using safe load method for yaml files
- consider state as valid if input_key is same as parameter and parameter is set