### PR TITLE
add missing dependencies of libnw.so

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -21,7 +21,6 @@
   <exec_depend>flexbe_widget</exec_depend>
   <exec_depend>genpy</exec_depend>
   <exec_depend>gtk3</exec_depend>  <!-- needed by libnw.so -->
-  <exec_depend>libatspi2.0-dev</exec_depend>  <!-- needed by libnw.so -->
   <exec_depend>libnss3-dev</exec_depend>
   <exec_depend>rospack</exec_depend>
   <exec_depend>rospy</exec_depend>

--- a/package.xml
+++ b/package.xml
@@ -20,6 +20,8 @@
   <exec_depend>flexbe_onboard</exec_depend>
   <exec_depend>flexbe_widget</exec_depend>
   <exec_depend>genpy</exec_depend>
+  <exec_depend>gtk3</exec_depend>  <!-- needed by libnw.so -->
+  <exec_depend>libatspi2.0-dev</exec_depend>  <!-- needed by libnw.so -->
   <exec_depend>libnss3-dev</exec_depend>
   <exec_depend>rospack</exec_depend>
   <exec_depend>rospy</exec_depend>


### PR DESCRIPTION
`libnw.so` requires some libraries (`libatspi2.0-dev` and `libgtk-3-dev`) to be installed but does not declare a dependency
thus, adding them to `flexbe_app`

this will fix the issue in `before_run_target_tests` for github actions (`mojin_flexbe`, `bmw`, `kevin_statemachine`, `mbl`) - see: https://github.com/mojin-robotics/cob4/issues/1509#issuecomment-770388137

~~requires https://github.com/ros/rosdistro/pull/28220~~