### PR TITLE
Throw Error if Concurrent Container has Outcome `preempted`

### DIFF
--- a/src/_helper/checking.js
+++ b/src/_helper/checking.js
@@ -147,6 +147,10 @@ Checking = new (function() {
 			return "state machine " + statemachine.getStatePath() + " has no initial state";
 		}
 
+		if (statemachine.isConcurrent() && statemachine.getOutcomes().contains("preempted")) {
+			return "state machine " + statemachine.getStatePath() + " has outcome 'preempted' which is not permitted for concurrency statemachines";
+		}
+
 		for (var i = 0; i < states.length; i++) {
 			var error_string = undefined;
 			if (states[i] instanceof Statemachine) {


### PR DESCRIPTION
The [`ConcurrencyContainer`](https://github.com/mojin-robotics/flexbe_behavior_engine/blob/develop/flexbe_core/src/flexbe_core/core/concurrency_container.py) class inherits from [`OperatableStateMachine`](https://github.com/mojin-robotics/flexbe_behavior_engine/blob/develop/flexbe_core/src/flexbe_core/core/operatable_state_machine.py) which itself inherits from [`PreemptableStateMachine`](https://github.com/mojin-robotics/flexbe_behavior_engine/blob/develop/flexbe_core/src/flexbe_core/core/preemptable_state_machine.py).

The `PreemtableStateMachine` has the [hard-coded](https://github.com/mojin-robotics/flexbe_behavior_engine/blob/2d56a6ba7e16e70ac8e5a371c56b860198d1db03/flexbe_core/src/flexbe_core/core/preemptable_state_machine.py#L16) outcome `preempted`. This causes exits of the behavior engine when a `ConcurrentContainer` triggers an outcome of the name `preempted`.

This PR adds an additional check for concurrent containers which throws an error if an outcome has the name `preempted`.