### PR TITLE
Revert "Throw Error if Concurrent Container has Outcome `preempted`"

### DIFF
--- a/src/_helper/checking.js
+++ b/src/_helper/checking.js
@@ -147,10 +147,6 @@ Checking = new (function() {
 			return "state machine " + statemachine.getStatePath() + " has no initial state";
 		}
 
-		if (statemachine.isConcurrent() && statemachine.getOutcomes().contains("preempted")) {
-			return "state machine " + statemachine.getStatePath() + " has outcome 'preempted' which is not permitted for concurrency statemachines";
-		}
-
 		for (var i = 0; i < states.length; i++) {
 			var error_string = undefined;
 			if (states[i] instanceof Statemachine) {


### PR DESCRIPTION
Reverts mojin-robotics/flexbe_app#19

we potentially have to revert or follow-up on this merge as it breaks e.g. afi and basf run_tests!

@deleh @benmaidel FYI