### PR TITLE
Change `version` to a Development Tag

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexBE App",
-  "version": "4am-dev",
+  "version": "2.2.2",
   "main": "src/main.js",
   "window": {
     "icon": "src/img/icon-128.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexBE App",
-  "version": "2.2.2",
+  "version": "2.4.0",
   "main": "src/main.js",
   "window": {
     "icon": "src/img/icon-128.png",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "FlexBE App",
-  "version": "2.3.0",
+  "version": "4am-dev",
   "main": "src/main.js",
   "window": {
     "icon": "src/img/icon-128.png",

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,7 @@
 <package format="2">
   <name>flexbe_app</name>
   <version>2.4.0</version>
+  <!-- NOTE: also sync the version in package.json when updating the version -->
   <description>
      flexbe_app provides a user interface (editor + runtime control) for the FlexBE behavior engine.
   </description>

--- a/src/ui/ui_feed.js
+++ b/src/ui/ui_feed.js
@@ -3,7 +3,7 @@ UI.Feed = new (function() {
 
 	var requestLatestVersion = function(callback) {
 		var xhr = new XMLHttpRequest();
-		xhr.open("GET", "https://api.github.com/repos/flexbe/flexbe_app/tags", true);
+		xhr.open("GET", "https://api.github.com/repos/mojin-robotics/flexbe_app/tags", true);
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState == 4) {
 				if (xhr.responseText != "") {


### PR DESCRIPTION
ref https://github.com/4am-robotics/orga/issues/4739

This prevents the *New release available!* popup and since we're using already a "custom" version it fits better than the default `version` tag.