### PR TITLE
remove kinetic job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - { ROS_DISTRO: kinetic }
           - { ROS_DISTRO: noetic }
 
     steps:


### PR DESCRIPTION
`install_catkin_lint` fails for `kinetic`:
```
  $ sudo python -m pip install -q catkin-lint
  Command "python setup.py egg_info" failed with error code 1 in /tmp/pip-build-arY_Y7/lxml/
  'sudo python -m pip install -q catkin-lint' returned with 1
'install_catkin_lint' returned with code '1' after 0 min 2 sec
```